### PR TITLE
feat: add configurable User-Agent header

### DIFF
--- a/scripts/debug-feed.ts
+++ b/scripts/debug-feed.ts
@@ -1,32 +1,18 @@
-import { Parser } from "../src/lib/feed-parser/parser";
+import { Parser } from "../src/domains/sync/feed-parser/parser";
+import { SyncLogger } from "../src/domains/sync/types";
 
-// Try different header sets to bypass Cloudflare
-const BROWSER_HEADERS = {
-  "user-agent":
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
-  accept:
-    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-  "accept-language": "en-US,en;q=0.9",
-  "cache-control": "max-age=0",
-  priority: "u=0, i",
-  "sec-ch-ua":
-    '"Chromium";v="130", "Google Chrome";v="130", "Not?A_Brand";v="99"',
-  "sec-ch-ua-mobile": "?0",
-  "sec-ch-ua-platform": '"macOS"',
-  "sec-fetch-dest": "document",
-  "sec-fetch-mode": "navigate",
-  "sec-fetch-site": "none",
-  "sec-fetch-user": "?1",
-  "upgrade-insecure-requests": "1",
-};
-
-const SIMPLE_HEADERS = {
+const BASE_HEADERS = {
   "user-agent": "FeedFetcher/1.0",
-  accept: "application/rss+xml, application/atom+xml, application/xml, text/xml",
+  accept:
+    "application/rss+xml, application/atom+xml, application/xml, text/xml",
 };
 
-// Default to simple headers - less likely to trigger Cloudflare
-const BASE_HEADERS = SIMPLE_HEADERS;
+const logger: SyncLogger = {
+  info: console.log,
+  warn: console.warn,
+  error: console.error,
+  debug: console.debug,
+};
 
 async function debugFeed(url: string) {
   console.log(`\n🔍 Debugging feed: ${url}\n`);
@@ -57,8 +43,8 @@ async function debugFeed(url: string) {
 
     // Parse the feed
     console.log("⚙️  Parsing feed...");
-    const parser = new Parser();
-    const result = await parser.parseString(xml);
+    const parser = new Parser({ logger });
+    const result = await parser.parseString(xml, {} as any);
     console.log(`✓ Parsed successfully\n`);
 
     // Display results
@@ -80,10 +66,8 @@ async function debugFeed(url: string) {
       const firstItem = result.items[0];
       console.log(`   Title: ${firstItem.title || "(no title)"}`);
       console.log(`   Link: ${firstItem.link || "(no link)"}`);
-      console.log(`   Date: ${firstItem.pubDate || "(no date)"}`);
-      console.log(
-        `   Author: ${firstItem.author || firstItem.creator || "(no author)"}`,
-      );
+      console.log(`   Date: ${firstItem.date || "(no date)"}`);
+      console.log(`   Author: ${firstItem.author || "(no author)"}`);
     }
 
     console.log("\n✅ Debug complete!\n");

--- a/src/app/admin/settings/(general)/page.tsx
+++ b/src/app/admin/settings/(general)/page.tsx
@@ -1,11 +1,13 @@
 import { DataRetentionSection } from "@/components/admin/settings/DataRetentionSection";
 import { SyncFrequencySection } from "@/components/admin/settings/SyncFrequencySection";
+import { UserAgentSection } from "@/components/admin/settings/UserAgentSection";
 import { TabsContent } from "@/components/ui/tabs";
 
 export default async function GeneralSettings() {
   return (
     <TabsContent value="general" className="my-4">
       <SyncFrequencySection />
+      <UserAgentSection />
       <DataRetentionSection />
     </TabsContent>
   );

--- a/src/components/admin/settings/UserAgentPreferenceForm.tsx
+++ b/src/components/admin/settings/UserAgentPreferenceForm.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { setPreference } from "@/domains/app-preferences/actions";
+import { UserAgentPreference } from "@/domains/app-preferences/schemas";
+import { useState } from "react";
+import { z } from "zod";
+
+interface UserAgentPreferenceFormProps {
+  value: z.infer<(typeof UserAgentPreference)["schema"]>;
+}
+
+export function UserAgentPreferenceForm({
+  value,
+}: UserAgentPreferenceFormProps) {
+  const [formValues, setFormValues] = useState(value);
+
+  async function handleChange(userAgent: string) {
+    const newValues = { userAgent };
+    setFormValues(newValues);
+    await setPreference(UserAgentPreference, newValues);
+  }
+
+  return (
+    <Input
+      type="text"
+      value={formValues.userAgent}
+      onChange={(e) => handleChange(e.target.value)}
+    />
+  );
+}

--- a/src/components/admin/settings/UserAgentSection.tsx
+++ b/src/components/admin/settings/UserAgentSection.tsx
@@ -1,0 +1,27 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { UserAgentPreference } from "@/domains/app-preferences/schemas";
+import { getPreference } from "@/domains/app-preferences/service";
+import { Info } from "lucide-react";
+import { UserAgentPreferenceForm } from "./UserAgentPreferenceForm";
+
+export async function UserAgentSection() {
+  const userAgent = await getPreference(UserAgentPreference);
+
+  return (
+    <section className="mb-10">
+      <h3 className="scroll-m-20 text-xl mb-4 font-semibold tracking-tight">
+        User Agent
+      </h3>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <UserAgentPreferenceForm value={userAgent} />
+        <Alert className="mb-auto">
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            The User-Agent header sent when fetching feeds. Some feed providers
+            may block requests based on this value.
+          </AlertDescription>
+        </Alert>
+      </div>
+    </section>
+  );
+}

--- a/src/domains/app-preferences/schemas.ts
+++ b/src/domains/app-preferences/schemas.ts
@@ -49,3 +49,18 @@ export const EventsHistoryRetentionPreference: AppPreference<
   key: AppPreferenceKey.EventsHistoryRetention,
   schema: eventsHistoryRetentionPreferenceSchema,
 };
+
+const userAgentPreferenceSchema = z.object({
+  userAgent: z
+    .string()
+    .catch(
+      "Mozilla/5.0 (compatible; OpenNewswire/1.0; +https://github.com/opennewswire)",
+    ),
+});
+
+export const UserAgentPreference: AppPreference<
+  typeof userAgentPreferenceSchema
+> = {
+  key: AppPreferenceKey.UserAgent,
+  schema: userAgentPreferenceSchema,
+};

--- a/src/domains/app-preferences/types.ts
+++ b/src/domains/app-preferences/types.ts
@@ -5,6 +5,7 @@ export enum AppPreferenceKey {
   SyncJobHistoryRetention = "syncJobHistoryRetention",
   ArticleRetention = "articleRetention",
   EventsHistoryRetention = "eventsHistoryRetention",
+  UserAgent = "userAgent",
 }
 
 export type AppPreferenceSchema = z.ZodTypeAny;

--- a/src/domains/sync/parser.ts
+++ b/src/domains/sync/parser.ts
@@ -1,3 +1,5 @@
+import { UserAgentPreference } from "@/domains/app-preferences/schemas";
+import { getPreference } from "@/domains/app-preferences/service";
 import { Feed } from "@/domains/feeds/types";
 import { Parser } from "@/domains/sync/feed-parser/parser";
 import { isBefore } from "date-fns";
@@ -11,7 +13,6 @@ import {
   TransientItem,
 } from "./types";
 
-// TODO: Make these configurable
 const BASE_HEADERS = {
   accept:
     "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
@@ -29,13 +30,20 @@ const BASE_HEADERS = {
   "upgrade-insecure-requests": "1",
 };
 
+async function getHeaders() {
+  const { userAgent } = await getPreference(UserAgentPreference);
+  return {
+    ...BASE_HEADERS,
+    "user-agent": userAgent,
+  };
+}
+
 /**
  * Fetches a feed, ignoring feed's last modified date and etag.
  */
 export async function forceFetch(url: string) {
-  const response = await fetch(url, {
-    headers: BASE_HEADERS,
-  });
+  const headers = await getHeaders();
+  const response = await fetch(url, { headers });
 
   return await response.text();
 }
@@ -53,9 +61,10 @@ export async function parseFeed(context: Context): Promise<ParserResult> {
   let allItems: TransientItem[] = [];
   let shouldContinue = true;
   let headers;
+  const requestHeaders = await getHeaders();
 
   do {
-    const fetchResult = await fetchFeed(url, feed);
+    const fetchResult = await fetchFeed(url, feed, requestHeaders);
 
     if (fetchResult.status === FetchStatus.NotModified) {
       return { status: FetchStatus.NotModified };
@@ -91,10 +100,10 @@ export async function parseFeed(context: Context): Promise<ParserResult> {
   };
 }
 
-async function fetchFeed(url: string, feed: Feed): Promise<FetchResult> {
+async function fetchFeed(url: string, feed: Feed, requestHeaders: Record<string, string>): Promise<FetchResult> {
   const response = await fetch(url, {
     headers: {
-      ...BASE_HEADERS,
+      ...requestHeaders,
       ...(feed.lastModifiedHeader && {
         "if-modified-since": feed.lastModifiedHeader,
       }),

--- a/src/utils/parse-website-icon.ts
+++ b/src/utils/parse-website-icon.ts
@@ -1,4 +1,4 @@
-import { ParserOutput } from "@/lib/feed-parser/types";
+import { ParserOutput } from "@/domains/sync/feed-parser/types";
 import getRootDomain from "@/utils/get-root-domain";
 import * as cheerio from "cheerio";
 import { parse } from "url";


### PR DESCRIPTION
## Summary
- Adds a new User Agent setting to the admin general settings page, allowing operators to customize the `User-Agent` header sent when fetching feeds
- Some feed providers block requests based on User-Agent, so this gives operators control to adjust it as needed
- Defaults to `Mozilla/5.0 (compatible; OpenNewswire/1.0; +https://github.com/opennewswire)`

## Test plan
- [x] Verify the User Agent section appears on the General settings page
- [x] Update the User-Agent value and confirm it persists across page reloads
- [x] Trigger a feed sync and confirm the custom User-Agent is used in outgoing requests