### PR TITLE
Prevent silent worker stalls (timeouts + abort signal)

### DIFF
--- a/src/domains/sync/executor.ts
+++ b/src/domains/sync/executor.ts
@@ -5,7 +5,7 @@ import { Status, SyncJob } from "@prisma/client";
 import { sub } from "date-fns";
 import { execute } from "./job";
 
-export async function run(job: SyncJob) {
+export async function run(job: SyncJob, signal?: AbortSignal) {
   const logger = new DatabaseLogger(job);
 
   try {
@@ -31,6 +31,7 @@ export async function run(job: SyncJob) {
       feed,
       policy: retentionPolicy,
       count: 0,
+      signal,
     };
 
     await execute(context);

--- a/src/domains/sync/parser.ts
+++ b/src/domains/sync/parser.ts
@@ -30,6 +30,13 @@ const BASE_HEADERS = {
   "upgrade-insecure-requests": "1",
 };
 
+const FETCH_TIMEOUT_MS = 7000;
+
+function requestSignal(taskSignal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  return taskSignal ? AbortSignal.any([timeout, taskSignal]) : timeout;
+}
+
 async function getHeaders() {
   const { userAgent } = await getPreference(UserAgentPreference);
   return {
@@ -41,9 +48,12 @@ async function getHeaders() {
 /**
  * Fetches a feed, ignoring feed's last modified date and etag.
  */
-export async function forceFetch(url: string) {
+export async function forceFetch(url: string, signal?: AbortSignal) {
   const headers = await getHeaders();
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, {
+    headers,
+    signal: requestSignal(signal),
+  });
 
   return await response.text();
 }
@@ -66,7 +76,12 @@ export async function parseFeed(context: Context): Promise<ParserResult> {
   const requestHeaders = await getHeaders();
 
   do {
-    const fetchResult = await fetchFeed(url, feed, requestHeaders);
+    const fetchResult = await fetchFeed(
+      url,
+      feed,
+      requestHeaders,
+      context.signal,
+    );
 
     if (fetchResult.status === FetchStatus.NotModified) {
       return { status: FetchStatus.NotModified };
@@ -110,6 +125,7 @@ async function fetchFeed(
   url: string,
   feed: Feed,
   requestHeaders: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<FetchResult> {
   const response = await fetch(url, {
     headers: {
@@ -121,7 +137,7 @@ async function fetchFeed(
         "if-none-match": feed.etag,
       }),
     },
-    signal: AbortSignal.timeout(7000),
+    signal: requestSignal(signal),
   });
 
   if (response.status === StatusCodes.NOT_MODIFIED) {

--- a/src/domains/sync/tasks/sync-feed.ts
+++ b/src/domains/sync/tasks/sync-feed.ts
@@ -1,5 +1,6 @@
 import { run } from "@/domains/sync/executor";
 import prisma from "@/lib/prisma";
+import { TimeoutAwareHelpers } from "@/lib/task-timeout";
 import { Status } from "@prisma/client";
 import { Task } from "graphile-worker";
 
@@ -7,15 +8,16 @@ interface SyncFeedPayload {
   jobId: string;
 }
 
-export const syncFeedTask: Task = async (payload, _helpers) => {
+export const syncFeedTask: Task = async (payload, helpers) => {
   const { jobId } = payload as SyncFeedPayload;
+  const { signal } = helpers as TimeoutAwareHelpers;
 
   const job = await prisma.syncJob.findUniqueOrThrow({
     where: { id: jobId },
     include: { feed: true },
   });
 
-  await run(job);
+  await run(job, signal);
 
   // If this is a child job, check if all siblings are done
   if (job.parentId) {

--- a/src/domains/sync/types.ts
+++ b/src/domains/sync/types.ts
@@ -56,6 +56,8 @@ export interface Context {
   policy: RetentionPolicy;
   // Total count of items parsed
   count: number;
+  // Aborts in-flight fetches if the task is cancelled (e.g. on timeout)
+  signal?: AbortSignal;
 }
 export interface PageResult {
   items: TransientItem[];

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -25,8 +25,23 @@ declare global {
 
 type ExtendedPrismaClient = ReturnType<typeof initPrismaClient>;
 
+const STATEMENT_TIMEOUT_MS = process.env.PG_STATEMENT_TIMEOUT_MS ?? "300000";
+const IDLE_IN_TXN_TIMEOUT_MS = process.env.PG_IDLE_IN_TXN_TIMEOUT_MS ?? "60000";
+
+function withConnectionTimeouts(url: string | undefined): string | undefined {
+  if (!url) return url;
+
+  const options = encodeURIComponent(
+    `-c statement_timeout=${STATEMENT_TIMEOUT_MS} ` +
+      `-c idle_in_transaction_session_timeout=${IDLE_IN_TXN_TIMEOUT_MS}`,
+  );
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}options=${options}`;
+}
+
 function initPrismaClient() {
   return new PrismaClient({
+    datasourceUrl: withConnectionTimeouts(process.env.POSTGRES_URL),
     omit: {
       user: {
         password_hash: true,

--- a/src/lib/task-timeout.test.ts
+++ b/src/lib/task-timeout.test.ts
@@ -1,0 +1,107 @@
+import { Task, JobHelpers } from "graphile-worker";
+import {
+  withTimeout,
+  withTimeouts,
+  TaskTimeoutError,
+  TimeoutAwareHelpers,
+} from "./task-timeout";
+
+function fakeHelpers(): JobHelpers {
+  return {
+    logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  } as unknown as JobHelpers;
+}
+
+describe("withTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the task result when it finishes before the deadline", async () => {
+    const wrapped = withTimeout("fast", 1000, async () => "done" as never);
+    await expect(wrapped({}, fakeHelpers())).resolves.toBe("done");
+  });
+
+  it("rejects with TaskTimeoutError and aborts the signal when it overruns", async () => {
+    vi.useFakeTimers();
+    const helpers = fakeHelpers();
+
+    let observedSignal: AbortSignal | undefined;
+    const hangs: Task = (_payload, h) => {
+      observedSignal = (h as TimeoutAwareHelpers).signal;
+      return new Promise<void>(() => {}); // never settles
+    };
+
+    const wrapped = withTimeout("hangs", 5000, hangs);
+    const result = wrapped({}, helpers);
+    const assertion = expect(result).rejects.toBeInstanceOf(TaskTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(helpers.logger.error).toHaveBeenCalledOnce();
+  });
+
+  it("exposes the abort signal on helpers without mutating the original", async () => {
+    const helpers = fakeHelpers();
+    let received: JobHelpers | undefined;
+    const wrapped = withTimeout("inspect", 1000, async (_p, h) => {
+      received = h;
+      return undefined;
+    });
+
+    await wrapped({}, helpers);
+
+    expect((received as TimeoutAwareHelpers).signal).toBeInstanceOf(AbortSignal);
+    expect("signal" in helpers).toBe(false);
+  });
+
+  it("throws when the budget is zero, negative, or NaN", () => {
+    expect(() => withTimeout("zero", 0, async () => undefined)).toThrow();
+    expect(() => withTimeout("negative", -1, async () => undefined)).toThrow();
+    expect(() => withTimeout("nan", NaN, async () => undefined)).toThrow();
+  });
+
+  it("does not arm a timer when the budget is infinite", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const wrappedInf = withTimeout("disabled", Infinity, async () => "ok2" as never);
+    await expect(wrappedInf({}, fakeHelpers())).resolves.toBe("ok2");
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates the task's own error untouched", async () => {
+    const boom = new Error("task failed");
+    const wrapped = withTimeout("boom", 1000, async () => {
+      throw boom;
+    });
+    await expect(wrapped({}, fakeHelpers())).rejects.toBe(boom);
+  });
+});
+
+describe("withTimeouts", () => {
+  it("applies per-task budgets and falls back to the default", async () => {
+    vi.useFakeTimers();
+    const helpers = fakeHelpers();
+
+    const list: Record<string, Task> = {
+      mapped: () => new Promise<void>(() => {}),
+      unmapped: () => new Promise<void>(() => {}),
+    };
+    const wrapped = withTimeouts(list, { mapped: 1000 }, 3000);
+
+    const mapped = wrapped.mapped({}, helpers);
+    const mappedAssertion = expect(mapped).rejects.toBeInstanceOf(TaskTimeoutError);
+    await vi.advanceTimersByTimeAsync(1000);
+    await mappedAssertion;
+
+    // The unmapped task uses the 3000ms default, so it is still pending at 1000ms.
+    const unmapped = wrapped.unmapped({}, helpers);
+    const unmappedAssertion = expect(unmapped).rejects.toBeInstanceOf(TaskTimeoutError);
+    await vi.advanceTimersByTimeAsync(3000);
+    await unmappedAssertion;
+  });
+});

--- a/src/lib/task-timeout.ts
+++ b/src/lib/task-timeout.ts
@@ -1,0 +1,84 @@
+import { JobHelpers, Task } from "graphile-worker";
+
+export class TaskTimeoutError extends Error {
+  constructor(taskName: string, timeoutMs: number) {
+    super(
+      `Task "${taskName}" exceeded its timeout of ${timeoutMs}ms and was aborted`,
+    );
+    this.name = "TaskTimeoutError";
+  }
+}
+
+export interface TimeoutAwareHelpers extends JobHelpers {
+  signal: AbortSignal;
+}
+
+/**
+ * Wraps a task so it rejects with {@link TaskTimeoutError} if it runs longer
+ * than `timeoutMs`.
+ *
+ * Note: racing a promise does not, by itself, stop the work behind it.
+ * The orphaned promise keeps running until it settles on its own. We additionally
+ * abort an {@link AbortController} so tasks that honour `helpers.signal` can
+ * unwind cleanly. Tasks that don't will still free their worker slot here.
+ */
+export function withTimeout(
+  taskName: string,
+  timeoutMs: number,
+  task: Task,
+): Task {
+  if (Number.isNaN(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `withTimeout("${taskName}") requires a positive timeout in milliseconds (or Infinity to disable); received ${timeoutMs}`,
+    );
+  }
+
+  return async (payload, helpers) => {
+    // Infinity means "no timeout" — run the task as-is without arming a timer.
+    if (!Number.isFinite(timeoutMs)) {
+      return task(payload, helpers);
+    }
+
+    const controller = new AbortController();
+    const augmentedHelpers: TimeoutAwareHelpers = Object.assign(
+      Object.create(Object.getPrototypeOf(helpers)),
+      helpers,
+      { signal: controller.signal },
+    );
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        helpers.logger.error(
+          `Task "${taskName}" exceeded ${timeoutMs}ms, aborting and failing the attempt`,
+        );
+        reject(new TaskTimeoutError(taskName, timeoutMs));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([task(payload, augmentedHelpers), timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Applies {@link withTimeout} to every task in a task list.
+ *
+ * `timeouts` maps task names to their time budget in milliseconds.
+ */
+export function withTimeouts(
+  taskList: Record<string, Task>,
+  timeouts: Record<string, number>,
+  defaultMs: number,
+): Record<string, Task> {
+  return Object.fromEntries(
+    Object.entries(taskList).map(([name, task]) => [
+      name,
+      withTimeout(name, timeouts[name] ?? defaultMs, task),
+    ]),
+  );
+}

--- a/src/lib/worker.ts
+++ b/src/lib/worker.ts
@@ -1,22 +1,24 @@
 import { SyncFrequencyPreference } from "@/domains/app-preferences/schemas";
 import { getPreference } from "@/domains/app-preferences/service";
 import {
-  rescheduleNextSyncAll,
-  syncAllTask,
-  syncFeedTask,
-  enrichEventsTask,
   cleanupArticlesTask,
   cleanupEventsTask,
   cleanupJobsTask,
+  enrichEventsTask,
+  rescheduleNextSyncAll,
+  syncAllTask,
+  syncFeedTask,
 } from "@/domains/sync/tasks";
+import { withTimeouts } from "@/lib/task-timeout";
 import {
   makeWorkerUtils,
   parseCronItems,
   run,
+  type CronItem,
   type Runner,
+  type Task,
   type TaskSpec,
   type WorkerUtils,
-  type CronItem,
 } from "graphile-worker";
 
 export const SYNC_FEED = "sync-feed";
@@ -25,6 +27,24 @@ export const ENRICH_EVENTS = "enrich-events";
 export const CLEANUP_ARTICLES = "cleanup-articles";
 export const CLEANUP_EVENTS = "cleanup-events";
 export const CLEANUP_JOBS = "cleanup-jobs";
+
+/**
+ * Per-task time budgets (ms). A task that overruns its budget is aborted and
+ * failed (then retried) rather than silently holding its worker slot forever.
+ */
+const DEFAULT_TASK_TIMEOUT_MS = parseInt(
+  process.env.WORKER_TASK_TIMEOUT_MS ?? "120000",
+  10,
+);
+
+const TASK_TIMEOUTS_MS: Record<string, number> = {
+  [SYNC_FEED]: 90_000,
+  [SYNC_ALL]: 180_000,
+  [ENRICH_EVENTS]: 300_000,
+  [CLEANUP_ARTICLES]: 900_000,
+  [CLEANUP_EVENTS]: 600_000,
+  [CLEANUP_JOBS]: 600_000,
+};
 
 let workerUtils: WorkerUtils | null = null;
 
@@ -78,20 +98,26 @@ export async function startWorker() {
 
   const parsedCrons = parseCronItems(cronItems);
 
+  const taskList: Record<string, Task> = {
+    [SYNC_FEED]: syncFeedTask,
+    [SYNC_ALL]: syncAllTask,
+    [ENRICH_EVENTS]: enrichEventsTask,
+    [CLEANUP_ARTICLES]: cleanupArticlesTask,
+    [CLEANUP_EVENTS]: cleanupEventsTask,
+    [CLEANUP_JOBS]: cleanupJobsTask,
+  };
+
   let runner: Runner;
 
   try {
     runner = await run({
       connectionString: process.env.POSTGRES_URL!,
       concurrency,
-      taskList: {
-        [SYNC_FEED]: syncFeedTask,
-        [SYNC_ALL]: syncAllTask,
-        [ENRICH_EVENTS]: enrichEventsTask,
-        [CLEANUP_ARTICLES]: cleanupArticlesTask,
-        [CLEANUP_EVENTS]: cleanupEventsTask,
-        [CLEANUP_JOBS]: cleanupJobsTask,
-      },
+      taskList: withTimeouts(
+        taskList,
+        TASK_TIMEOUTS_MS,
+        DEFAULT_TASK_TIMEOUT_MS,
+      ),
       parsedCronItems: parsedCrons,
     });
 


### PR DESCRIPTION
Attempts to fix silent worker stalls where a hung `sync-feed` task held its slot forever (with no logs or error).

- **Per-task timeouts**: each task gets a time budget. On overrun it throws so the slot frees and the job retries instead of hanging.
- **Abort on timeout**: the timeout signal is threaded into the feed `fetch`, so a timed-out sync cancels the request and releases its DB connection.
- **DB guards**: Prisma connections set `statement_timeout` (5m) and `idle_in_transaction_session_timeout` (60s), env-overridable.
